### PR TITLE
Stems to put filesets and cleaner escaping of label names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from pathlib import Path
+import typing as ty
 from datetime import datetime
 import shutil
 from tempfile import mkdtemp
@@ -46,7 +47,7 @@ PKG_DIR = Path(__file__).parent
 
 
 @pytest.fixture
-def work_dir():
+def work_dir() -> Path:
     # work_dir = Path.home() / '.frametree-tests'
     # work_dir.mkdir(exist_ok=True)
     # return work_dir
@@ -56,7 +57,7 @@ def work_dir():
 
 
 @pytest.fixture(scope="session")
-def build_cache_dir():
+def build_cache_dir() -> Path:
     # build_cache_dir = Path.home() / '.frametree-test-build-cache'
     # if build_cache_dir.exists():
     #     shutil.rmtree(build_cache_dir)
@@ -76,12 +77,12 @@ def cli_runner(catch_cli_exceptions):
 
 
 @pytest.fixture(scope="session")
-def pkg_dir():
+def pkg_dir() -> Path:
     return PKG_DIR
 
 
 @pytest.fixture(scope="session")
-def run_prefix():
+def run_prefix() -> str:
     "A datetime string used to avoid stale data left over from previous tests"
     return datetime.strftime(datetime.now(), "%Y%m%d%H%M%S")
 
@@ -130,15 +131,15 @@ def pydra_task(request):
 DATA_STORES = ["file_system", "mock_remote"]
 
 
-@pytest.fixture
-def frametree_home(work_dir):
-    frametree_home = work_dir / "frametree-home"
+@pytest.fixture(scope="session")
+def frametree_home() -> Path:
+    frametree_home = Path(mkdtemp()) / "frametree-home"
     with patch.dict(os.environ, {"FRAMETREE_HOME": str(frametree_home)}):
         yield frametree_home
 
 
 @pytest.fixture(params=DATA_STORES)
-def data_store(work_dir: Path, frametree_home: Path, request):
+def data_store(work_dir: Path, frametree_home: Path, request: ty.Any) -> Store:
     store: Store
     if request.param == "file_system":
         store = FileSystem()

--- a/frametree/common/__init__.py
+++ b/frametree/common/__init__.py
@@ -1,2 +1,4 @@
 from .file_system import FileSystem
 from .axes import Clinical, Samples
+
+__all__ = ["FileSystem", "Clinical", "Samples"]

--- a/frametree/core/__init__.py
+++ b/frametree/core/__init__.py
@@ -5,4 +5,6 @@ CODE_URL = f"https://github.com/ArcanaFramework/{PACKAGE_NAME}"
 
 __authors__ = [("Thomas G. Close", "tom.g.close@gmail.com")]
 
-from .frameset import FrameSet  # noqa: F401
+from .frameset import FrameSet  # noqa: E402
+
+__all__ = ["FrameSet"]

--- a/frametree/core/column.py
+++ b/frametree/core/column.py
@@ -226,7 +226,7 @@ class DataColumn(metaclass=ABCMeta):
 
 
 @attrs.define(kw_only=True)
-class DataSource(DataColumn):
+class SourceColumn(DataColumn):
     """
     Specifies the criteria by which an item is selected from a data row to
     be a data source.
@@ -367,7 +367,7 @@ class DataSource(DataColumn):
 
 
 @attrs.define(kw_only=True)
-class DataSink(DataColumn):
+class SinkColumn(DataColumn):
     """
     A specification for a file set within a analysis to be derived from a
     processing pipeline.

--- a/frametree/core/entry.py
+++ b/frametree/core/entry.py
@@ -119,7 +119,7 @@ class DataEntry:
             item = self.datatype(item)
         self.row.frameset.store.put(self, item)
 
-    def get_item(self, datatype=None):
+    def get_item(self, datatype: ty.Optional[ty.Type[DataType]] = None) -> DataType:
         if datatype is None:
             datatype = self.datatype
         return self.row.frameset.store.get(self, datatype)

--- a/frametree/core/exceptions.py
+++ b/frametree/core/exceptions.py
@@ -65,7 +65,7 @@ class FrameTreeDesignError(FrameTreeError):
 
 
 class NamedFrameTreeError(FrameTreeError):
-    def __init__(self, name, msg):
+    def __init__(self, name: str, msg: str) -> None:
         super(NamedFrameTreeError, self).__init__(msg)
         self.name = name
 
@@ -79,7 +79,7 @@ class FrameTreeWrongFrequencyError(NamedFrameTreeError):
 
 
 class FrameTreeIndexError(FrameTreeError):
-    def __init__(self, index, msg):
+    def __init__(self, index: int, msg: str) -> None:
         super(FrameTreeIndexError, self).__init__(msg)
         self.index = index
 

--- a/frametree/core/frameset/__init__.py
+++ b/frametree/core/frameset/__init__.py
@@ -1,2 +1,4 @@
 from .base import FrameSet
 from .metadata import Metadata
+
+__all__ = ["FrameSet", "Metadata"]

--- a/frametree/core/frameset/base.py
+++ b/frametree/core/frameset/base.py
@@ -4,9 +4,11 @@ import re
 import typing as ty
 from pathlib import Path
 import shutil
+from warnings import warn
 import attrs
 import attrs.filters
 from attrs.converters import default_if_none
+from typing_extensions import Self
 from pydra.utils.hash import hash_single, bytes_repr_mapping_contents
 from fileformats.text import Plain as PlainText
 from frametree.core.exceptions import (
@@ -338,6 +340,16 @@ class FrameSet:
                 return cls(id, store, **kwargs)
             raise
 
+    def reload(self) -> Self:
+        """Reload the frameset from the store
+
+        Returns
+        -------
+        FrameSet
+            The reloaded frame-set
+        """
+        return self.store.load_frameset(self.id, name=self.name)
+
     @property
     def root_freq(self):
         return self.axes(0)
@@ -374,16 +386,21 @@ class FrameSet:
             return self.tree.root
 
     @property
-    def locator(self):
+    def address(self):
         if self.store.name is None:
             raise Exception(
                 f"Must save store {self.store} first before accessing locator for "
                 f"{self}"
             )
-        locator = f"{self.store.name}//{self.id}"
+        address = f"{self.store.name}//{self.id}"
         if self.name:
-            locator += f"@{self.name}"
-        return locator
+            address += f"@{self.name}"
+        return address
+
+    @property
+    def locator(self):
+        warn("'FrameSet.locator' is deprecated use, 'address' instead'")
+        return self.address
 
     def add_source(
         self,

--- a/frametree/core/packaging.py
+++ b/frametree/core/packaging.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from typing import Sequence
 import json
+import typing as ty
 import importlib_metadata
 import pkgutil
 from importlib import import_module
@@ -72,7 +72,7 @@ def list_subclasses(package, base_class, subpkg=None):
     return subclasses
 
 
-def package_from_module(module: Sequence[str]):
+def package_from_module(module: Iterable[str]) -> ty.Any:
     """Resolves the installed package (e.g. from PyPI) that provides the given
     module.
 
@@ -177,7 +177,7 @@ def installed_module_paths(pkg: pkg_resources.DistInfoDistribution):
     return paths
 
 
-def pkg_versions(modules):
+def pkg_versions(modules: Iterable[str]) -> dict[str, str]:
     versions = {p.key: p.version for p in package_from_module(modules)}
     versions[PACKAGE_NAME] = __version__
     return versions

--- a/frametree/core/pipeline.py
+++ b/frametree/core/pipeline.py
@@ -4,6 +4,7 @@ import typing as ty
 from collections import OrderedDict
 import logging
 from copy import copy, deepcopy
+from typing_extensions import Self
 import attrs.converters
 import pydra.mark
 from pydra.engine.core import Workflow
@@ -400,13 +401,15 @@ class Pipeline:
     PROVENANCE_VERSION = "1.0"
     WORKFLOW_NAME = "processing"
 
-    def asdict(self, required_modules=None):
+    def asdict(
+        self, required_modules: ty.Optional[ty.Set[str]] = None
+    ) -> ty.Dict[str, ty.Any]:
         dct = asdict(self, omit=["workflow"], required_modules=required_modules)
         dct["workflow"] = pydra_asdict(self.workflow, required_modules=required_modules)
         return dct
 
     @classmethod
-    def fromdict(cls, dct, **kwargs):
+    def fromdict(cls, dct: ty.Dict[str, ty.Any], **kwargs: ty.Any) -> Self:
         return fromdict(dct, workflow=pydra_fromdict(dct["workflow"]), **kwargs)
 
     @classmethod
@@ -416,12 +419,12 @@ class Pipeline:
 
         Parameters
         ----------
-        sinks : Iterable[DataSink or str]
+        sinks : Iterable[SinkColumn or str]
             the sink columns, or their names, that are to be generated
 
         Returns
         -------
-        ty.List[tuple[Pipeline, ty.List[DataSink]]]
+        ty.List[tuple[Pipeline, ty.List[SinkColumn]]]
             stack of pipelines required to produce the specified data sinks,
             along with the sinks each stage needs to produce.
 
@@ -442,7 +445,7 @@ class Pipeline:
 
             Parameters
             ----------
-            sink: DataSink
+            sink: SinkColumn
                 the sink to push its deriving pipeline for
             downstream : tuple[Pipeline]
                 The pipelines directly downstream of the pipeline to be added.

--- a/frametree/core/pipeline.py
+++ b/frametree/core/pipeline.py
@@ -35,6 +35,8 @@ from .serialize import (
     ClassResolver,
     ObjectListConverter,
 )
+from .column import SinkColumn
+from .frameset.base import FrameSet
 
 
 logger = logging.getLogger("frametree")
@@ -66,7 +68,7 @@ class PipelineField:
     )
 
     @field.default
-    def field_default(self):
+    def field_default(self) -> str:
         return self.name
 
 
@@ -120,13 +122,13 @@ class Pipeline:
         metadata={"asdict": False}, default=None, eq=False, hash=False
     )
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         for field in self.inputs + self.outputs:
             if field.datatype is None:
                 field.datatype = self.frameset[field.name].datatype
 
     @inputs.validator
-    def inputs_validator(self, _, inputs: ty.List[PipelineField]):
+    def inputs_validator(self, _: ty.Any, inputs: ty.List[PipelineField]) -> None:
         for inpt in inputs:
             if inpt.datatype is frametree.core.row.DataRow:  # special case
                 continue
@@ -155,7 +157,7 @@ class Pipeline:
                 )
 
     @outputs.validator
-    def outputs_validator(self, _, outputs: ty.List[PipelineField]):
+    def outputs_validator(self, _: ty.Any, outputs: ty.List[PipelineField]) -> None:
         for outpt in outputs:
             if self.frameset:
                 column = self.frameset[outpt.name]
@@ -187,13 +189,13 @@ class Pipeline:
                 )
 
     @property
-    def input_varnames(self):
+    def input_varnames(self) -> ty.List[str]:
         return [
             i.name for i in self.inputs
         ]  # [path2varname(i.name) for i in self.inputs]
 
     @property
-    def output_varnames(self):
+    def output_varnames(self) -> ty.List[str]:
         return [
             o.name for o in self.outputs
         ]  # [path2varname(o.name) for o in self.outputs]
@@ -202,7 +204,7 @@ class Pipeline:
     # self.wf.to_process.inputs.parameterisation = parameterisation
     # self.wf.per_node.source.inputs.parameterisation = parameterisation
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs: ty.Any) -> Workflow:
         """
         Create an "outer" workflow that interacts with the dataset to pull input
         data, process it and then push the derivatives back to the store.
@@ -413,7 +415,9 @@ class Pipeline:
         return fromdict(dct, workflow=pydra_fromdict(dct["workflow"]), **kwargs)
 
     @classmethod
-    def stack(cls, *sinks):
+    def stack(
+        cls, *sinks: ty.Union[SinkColumn, str]
+    ) -> ty.List[ty.Tuple["Pipeline", ty.List[SinkColumn]]]:
         """Determines the pipelines stack, in order of execution,
         required to generate the specified sink columns.
 
@@ -437,7 +441,9 @@ class Pipeline:
         # Stack of pipelines to process in reverse order of required execution
         stack = OrderedDict()
 
-        def push_pipeline_on_stack(sink, downstream: ty.Tuple[Pipeline] = None):
+        def push_pipeline_on_stack(
+            sink: SinkColumn, downstream: ty.Optional[ty.Tuple[Pipeline]] = None
+        ) -> None:
             """
             Push a pipeline onto the stack of pipelines to be processed,
             detecting common upstream pipelines and resolving them to a single
@@ -511,25 +517,27 @@ class Pipeline:
         return reversed(stack.values())
 
 
-def append_side_car_suffix(name, suffix):
+def append_side_car_suffix(name: str, suffix: str) -> str:
     """Creates a new combined field name out of a basename and a side car"""
     return f"{name}__o__{suffix}"
 
 
-def split_side_car_suffix(name):
+def split_side_car_suffix(name: str) -> ty.List[str]:
     """Splits the basename from a side car sufix (as combined by `append_side_car_suffix`"""
     return name.split("__o__")
 
 
-@pydra.mark.task
-@pydra.mark.annotate({"return": {"ids": ty.List[str], "cant_process": ty.List[str]}})
+@pydra.mark.task  # type: ignore[misc]
+@pydra.mark.annotate(
+    {"return": {"ids": ty.List[str], "cant_process": ty.List[str]}}
+)  # type: ignore[misc]
 def to_process(
     dataset: frametree.core.frameset.base.FrameSet,
     row_frequency: Axes,
     outputs: ty.List[PipelineField],
     requested_ids: ty.Union[ty.List[str], None],
     parameterisation: ty.Dict[str, ty.Any],
-):
+) -> ty.Tuple[ty.List[str], bool]:
     if requested_ids is None:
         requested_ids = dataset.row_ids(row_frequency)
     ids = []
@@ -554,8 +562,10 @@ def source_items(
     row_frequency: Axes,
     id: str,
     inputs: ty.List[PipelineField],
-    parameterisation: dict,
-):
+    parameterisation: ty.Dict[str, ty.Any],
+) -> ty.Tuple[
+    ty.Union["frametree.core.row.DataRow", DataType, ty.Dict[str, ty.Any]], ...
+]:
     """Selects the items from the dataset corresponding to the input
     sources and retrieves them from the store to a cache on
     the host
@@ -570,10 +580,15 @@ def source_items(
         the ID of the row to source from
     parameterisation : dict
         provenance information... can't remember why this was used here...
+
+    Returns
+    -------
+    tuple
+        the sourced data items
     """
     logger.debug("Sourcing %s", inputs)
-    provenance = copy(parameterisation)
-    sourced = []
+    parameterisation = copy(parameterisation)
+    sourced: ty.List[ty.Union["frametree.core.row.DataRow", DataType]] = []
     row = dataset.row(row_frequency, id)
     with dataset.store.connection:
         missing_inputs = {}
@@ -589,10 +604,16 @@ def source_items(
                 missing_inputs[inpt.name] = str(e)
         if missing_inputs:
             raise FrameTreeDataMatchError("\n\n" + "\n\n".join(missing_inputs.values()))
-    return tuple(sourced) + (provenance,)
+    return tuple(sourced) + (parameterisation,)
 
 
-def sink_items(dataset, row_frequency, id, provenance, **to_sink):
+def sink_items(
+    dataset: FrameSet,
+    row_frequency: Axes,
+    id: str,
+    provenance: ty.Dict[str, ty.Any],
+    **to_sink: ty.Any,
+) -> str:
     """Stores items generated by the pipeline back into the store
 
     Parameters
@@ -607,6 +628,11 @@ def sink_items(dataset, row_frequency, id, provenance, **to_sink):
         provenance information to be stored alongside the generated data
     **to_sink : dict[str, DataType]
         data items to be stored in the data store
+
+    Returns
+    -------
+    str
+        the ID of the row that was processed
     """
     logger.debug("Sinking %s", to_sink)
     row = dataset.row(row_frequency, id)

--- a/frametree/core/serialize.py
+++ b/frametree/core/serialize.py
@@ -484,7 +484,7 @@ def pydra_asdict(
     return dct
 
 
-def lazy_field_fromdict(dct: dict, workflow: Workflow):
+def lazy_field_fromdict(dct: ty.Dict[ty.Any, ty.Any], workflow: Workflow) -> LazyField:
     """Unserialises a LazyField object from a dictionary"""
     if "task" in dct:
         inpt_task = getattr(workflow, dct["task"])
@@ -495,7 +495,9 @@ def lazy_field_fromdict(dct: dict, workflow: Workflow):
 
 
 def pydra_fromdict(
-    dct: dict, workflow: ty.Optional[Workflow] = None, **kwargs
+    dct: ty.Dict[ty.Any, ty.Any],
+    workflow: ty.Optional[Workflow] = None,
+    **kwargs: ty.Any,
 ) -> TaskBase:
     """Recreates a Pydra Task/Workflow from a dictionary object created by
     `pydra_asdict`
@@ -552,10 +554,10 @@ class ObjectConverter:
     accept_metadata: bool = False
     package: str = PACKAGE_NAME
 
-    def __call__(self, value):
+    def __call__(self, value: ty.Any) -> ty.Any:
         return self._create_object(value)
 
-    def _create_object(self, value, **kwargs):
+    def _create_object(self, value: ty.Any, **kwargs: ty.Any) -> ty.Any:
         if value is None:
             if kwargs:
                 value = {}
@@ -612,8 +614,8 @@ class ObjectConverter:
 
 @attrs.define
 class ObjectListConverter(ObjectConverter):
-    def __call__(self, value):
-        converted = []
+    def __call__(self, value: ty.Any) -> ty.List[ty.Any]:
+        converted: ty.List[ty.Any] = []
         if value is None:
             if self.allow_none:
                 return converted
@@ -628,7 +630,7 @@ class ObjectListConverter(ObjectConverter):
         return converted
 
     @classmethod
-    def asdict(cls, objs: list, **kwargs) -> dict:
+    def asdict(cls, objs: ty.List[ty.Any], **kwargs: ty.Any) -> ty.Dict[str, ty.Any]:
         dct = {}
         for obj in objs:
             obj_dict = attrs.asdict(obj, **kwargs)
@@ -636,11 +638,11 @@ class ObjectListConverter(ObjectConverter):
         return dct
 
     @classmethod
-    def aslist(cls, objs: list, **kwargs) -> list:
+    def aslist(cls, objs: ty.List[ty.Any], **kwargs: ty.Any) -> ty.List[ty.Any]:
         return [attrs.asdict(obj, **kwargs) for obj in objs]
 
 
-def parse_value(value):
+def parse_value(value: ty.Any) -> ty.Any:
     """Parses values from string representations"""
     try:
         value = json.loads(

--- a/frametree/core/serialize.py
+++ b/frametree/core/serialize.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import is_dataclass, fields as dataclass_fields
 from typing import Sequence
 import typing as ty
+from types import TracebackType
 from enum import Enum
 import builtins
 from copy import copy
@@ -41,10 +42,15 @@ class _FallbackContext:
 
     permit: bool = False
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.permit = True
 
-    def __exit__(self, exception_type, exception_value, traceback):
+    def __exit__(
+        self,
+        exception_type: ty.Optional[ty.Type[BaseException]],
+        exception_value: ty.Optional[BaseException],
+        traceback: ty.Optional[TracebackType],
+    ) -> None:
         self.permit = False
 
 
@@ -121,14 +127,16 @@ class ClassResolver:
         return klass
 
     @classmethod
-    def _get_subpkg(cls, klass):
+    def _get_subpkg(cls, klass: ty.Type[ty.Any]) -> ty.Optional[str]:
         try:
             return klass.SUBPACKAGE
         except AttributeError:
             return None
 
     @classmethod
-    def fromstr(cls, class_str, subpkg=None, pkg=PACKAGE_NAME):
+    def fromstr(
+        cls, class_str: str, subpkg: ty.Optional[str] = None, pkg: str = PACKAGE_NAME
+    ) -> ty.Union[ty.Type[ty.Any], ty.Callable]:
         """Resolves a class/function from a string containing its module an its name
         separated by a ':'
 
@@ -211,7 +219,7 @@ class ClassResolver:
         return klass
 
     @classmethod
-    def tostr(cls, klass, strip_prefix: bool = True):
+    def tostr(cls, klass: ty.Type[ty.Any], strip_prefix: bool = True) -> str:
         """Records the location of a class so it can be loaded later using
         `ClassResolver`, in the format <module-name>:<class-name>
 
@@ -242,7 +250,7 @@ class ClassResolver:
                 module_name += "."  # To distinguish it from extension module name
         return module_name + ":" + klass.__name__
 
-    def _check_type(self, klass):
+    def _check_type(self, klass: ty.Type[ty.Any]) -> None:
         if self.FALLBACK_TO_STR.permit and isinstance(klass, str):
             return
         if self.base_class:
@@ -267,7 +275,11 @@ class ClassResolver:
     FALLBACK_TO_STR = _FallbackContext()
 
 
-def asdict(obj, omit: ty.Iterable[str] = (), required_modules: ty.Optional[set] = None):
+def asdict(
+    obj: ty.Any,
+    omit: ty.Iterable[str] = (),
+    required_modules: ty.Optional[ty.Set[str]] = None,
+) -> ty.Dict[str, ty.Any]:
     """Serialises an object of a class defined with attrs to a dictionary
 
     Parameters
@@ -277,10 +289,16 @@ def asdict(obj, omit: ty.Iterable[str] = (), required_modules: ty.Optional[set] 
         decorator
     omit: Iterable[str]
         the names of attributes to omit from the dictionary
-    required_modules: set
-        modules required to reload the serialised object into memory"""
+    required_modules: set[str], optional
+        modules required to reload the serialised object into memory
 
-    def filter(atr, value):
+    Returns
+    -------
+    dict
+        the serialised object
+    """
+
+    def filter(atr: attrs.Attribute[ty.Any], value: ty.Any) -> bool:
         return atr.init and atr.metadata.get("asdict", True)
 
     if required_modules is None:
@@ -289,11 +307,11 @@ def asdict(obj, omit: ty.Iterable[str] = (), required_modules: ty.Optional[set] 
     else:
         include_versions = False
 
-    def serialise_class(klass):
+    def serialise_class(klass: ty.Type[ty.Any]) -> str:
         required_modules.add(klass.__module__)
         return "<" + ClassResolver.tostr(klass, strip_prefix=False) + ">"
 
-    def value_asdict(value):
+    def value_asdict(value: ty.Any) -> ty.Dict[str, ty.Any]:
         if isclass(value):
             value = serialise_class(value)
         elif hasattr(value, "asdict"):
@@ -338,14 +356,14 @@ def asdict(obj, omit: ty.Iterable[str] = (), required_modules: ty.Optional[set] 
     return dct
 
 
-def _replace_hidden(dct):
+def _replace_hidden(dct: ty.Dict[str, ty.Any]) -> None:
     "Replace hidden attributes (those starting with '_') with non-hidden"
     for key in list(dct):
         if key.startswith("_"):
             dct[key[1:]] = dct.pop(key)
 
 
-def fromdict(dct: dict, **kwargs):
+def fromdict(dct: ty.Dict[str, ty.Any], **kwargs: ty.Any) -> object:
     """Unserialise an object from a dict created by the `asdict` method
 
     Parameters
@@ -370,33 +388,46 @@ def fromdict(dct: dict, **kwargs):
     #                 f"read by this version of frametree ('{__version__}'), the minimum "
     #                 f"version is {MIN_SERIAL_VERSION}")
 
-    def field_filter(klass, field_name):
+    def field_filter(klass: ty.Type[ty.Any], field_name: str) -> bool:
         if attrs.has(klass):
             return field_name in (f.name for f in attrs.fields(klass))
         else:
             return field_name != "class"
 
-    def fromdict(value):
+    def fromdict(
+        value: ty.Union[
+            ty.Dict[str, ty.Any],
+            str,
+            ty.Sequence[ty.Dict[str, ty.Any]],
+        ]
+    ) -> ty.Any:
+        resolved_value: ty.Any = value
         if isinstance(value, dict):
             if "class" in value:
                 klass = ClassResolver()(value["class"])
                 if hasattr(klass, "fromdict"):
                     return klass.fromdict(value)
-            value = {fromdict(k): fromdict(v) for k, v in value.items()}
-            if "class" in value:
-                value = klass(
-                    **{k: v for k, v in value.items() if field_filter(klass, k)}
+            resolved_value = {fromdict(k): fromdict(v) for k, v in value.items()}
+            if "class" in resolved_value:
+                resolved_value = klass(
+                    **{
+                        k: v
+                        for k, v in resolved_value.items()
+                        if field_filter(klass, k)
+                    }
                 )
         elif isinstance(value, str):
             if match := re.match(r"<(.*)>$", value):  # Class location
-                value = ClassResolver()(match.group(1))
-            elif match := re.match(r"<(.*)>\[(.*)\]$", value):  # Enum
-                value = ClassResolver()(match.group(1))[match.group(2)]
+                resolved_value = ClassResolver()(match.group(1))
+            elif match := re.match(
+                r"<(.*)>\[(.*)\]$", value
+            ):  # Enum or classified format
+                resolved_value = ClassResolver()(match.group(1))[match.group(2)]  # type: ignore[index]
             elif match := re.match(r"file://(.*)", value):
-                value = Path(match.group(1))
+                resolved_value = Path(match.group(1))
         elif isinstance(value, Sequence):
-            value = [fromdict(x) for x in value]
-        return value
+            resolved_value = [fromdict(x) for x in value]
+        return resolved_value
 
     klass = ClassResolver()(dct["class"])
 
@@ -418,7 +449,7 @@ NOTHING_STR = "__PIPELINE_INPUT__"
 
 def pydra_asdict(
     obj: TaskBase, required_modules: ty.Set[str], workflow: ty.Optional[Workflow] = None
-) -> dict:
+) -> ty.Dict[str, ty.Any]:
     """Converts a Pydra Task/Workflow into a dictionary that can be serialised
 
     Parameters

--- a/frametree/core/store/__init__.py
+++ b/frametree/core/store/__init__.py
@@ -1,3 +1,5 @@
 from .base import Store
 from .local import LocalStore
 from .remote import RemoteStore
+
+__all__ = ["Store", "LocalStore", "RemoteStore"]

--- a/frametree/core/store/base.py
+++ b/frametree/core/store/base.py
@@ -11,6 +11,7 @@ from frametree.core.serialize import (
     fromdict,
 )
 import frametree
+from ..axes import Axes
 from fileformats.core import DataType
 from fileformats.text import Plain as PlainText
 from frametree.core.utils import (
@@ -95,7 +96,7 @@ class Store(metaclass=ABCMeta):
 
     def save(
         self, name: ty.Optional[str] = None, config_path: ty.Optional[Path] = None
-    ):
+    ) -> None:
         """Saves the configuration of a Store in 'stores.yaml'
 
         Parameters
@@ -126,11 +127,13 @@ class Store(metaclass=ABCMeta):
             entries[dct.pop("name")] = dct
         self.save_configs(entries, config_path=config_path)
 
-    def asdict(self, **kwargs):
+    def asdict(self, **kwargs: ty.Any) -> ty.Dict[str, ty.Any]:
         return asdict(self, **kwargs)
 
     @classmethod
-    def load(cls, name: str, config_path: ty.Optional[Path] = None, **kwargs) -> Store:
+    def load(
+        cls, name: str, config_path: ty.Optional[Path] = None, **kwargs: ty.Any
+    ) -> Store:
         """Loads a Store from that has been saved in the configuration file.
         If no entry is saved under that name, then it searches for Store
         sub-classes with aliases matching `name` and checks whether they can
@@ -186,7 +189,12 @@ class Store(metaclass=ABCMeta):
         cls.save_configs(entries)
 
     def define_frameset(
-        self, id, axes=None, hierarchy=None, id_patterns=None, **kwargs
+        self,
+        id: str,
+        axes: ty.Type[Axes] = None,
+        hierarchy: ty.List[ty.Union[str, Axes]] = None,
+        id_patterns: ty.Optional[ty.Dict[str, str]] = None,
+        **kwargs: ty.Any,
     ) -> FrameSet:
         """
         Creates a FrameTree dataset definition for an existing data in the
@@ -240,7 +248,7 @@ class Store(metaclass=ABCMeta):
         )
         return dataset
 
-    def save_frameset(self, frameset: FrameSet, name: str = ""):
+    def save_frameset(self, frameset: FrameSet, name: str = "") -> None:
         """Save metadata in project definition file for future reference
 
         Parameters
@@ -261,7 +269,7 @@ class Store(metaclass=ABCMeta):
         with self.connection:
             self.save_frameset_definition(frameset.id, definition, name=save_name)
 
-    def load_frameset(self, id, name: str = "", **kwargs) -> FrameSet:
+    def load_frameset(self, id: str, name: str = "", **kwargs: ty.Any) -> FrameSet:
         """Load an existing dataset definition
 
         Parameters
@@ -291,7 +299,7 @@ class Store(metaclass=ABCMeta):
             raise KeyError(f"Did not find a dataset '{id}@{name}'")
         store_version = dct.pop(self.VERSION_KEY)
         self.check_store_version(store_version)
-        return fromdict(dct, id=id, name=name, store=self, **kwargs)
+        return fromdict(dct, id=id, name=name, store=self, **kwargs)  # type: ignore[no-any-return]
 
     def create_dataset(
         self,

--- a/frametree/core/store/base.py
+++ b/frametree/core/store/base.py
@@ -28,6 +28,7 @@ from frametree.core.exceptions import (
 
 
 S = ty.TypeVar("S", bound="Store")
+DT = ty.TypeVar("DT", bound="DataType")
 
 logger = logging.getLogger("frametree")
 
@@ -44,13 +45,13 @@ class ConnectionManager(NestedContext):
     store: ty.Any = None
     session: ty.Any = attrs.field(default=None, init=False)
 
-    def __getattr__(self, attr_name):
+    def __getattr__(self, attr_name: str) -> ty.Any:
         return getattr(self.session, attr_name)
 
-    def enter(self):
+    def enter(self) -> None:
         self.session = self.store.connect()
 
-    def exit(self):
+    def exit(self) -> None:
         self.store.disconnect(self.session)
         self.session = None
 
@@ -79,7 +80,7 @@ class Store(metaclass=ABCMeta):
         factory=ConnectionManager, init=False, hash=False, repr=False, eq=False
     )
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         self.connection.store = self
 
     CONFIG_NAME = "stores"
@@ -176,7 +177,7 @@ class Store(metaclass=ABCMeta):
         return store
 
     @classmethod
-    def remove(cls, name: str, config_path: ty.Optional[Path] = None):
+    def remove(cls, name: str, config_path: ty.Optional[Path] = None) -> None:
         """Removes the entry saved under 'name' in the config file
 
         Parameters
@@ -191,8 +192,8 @@ class Store(metaclass=ABCMeta):
     def define_frameset(
         self,
         id: str,
-        axes: ty.Type[Axes] = None,
-        hierarchy: ty.List[ty.Union[str, Axes]] = None,
+        axes: ty.Optional[ty.Type[Axes]] = None,
+        hierarchy: ty.Optional[ty.List[ty.Union[str, Axes]]] = None,
         id_patterns: ty.Optional[ty.Dict[str, str]] = None,
         **kwargs: ty.Any,
     ) -> FrameSet:
@@ -309,7 +310,7 @@ class Store(metaclass=ABCMeta):
         axes: type,
         name: ty.Optional[str] = None,
         id_patterns: ty.Optional[ty.Dict[str, str]] = None,
-        **kwargs,
+        **kwargs: ty.Any,
     ) -> FrameSet:
         """Creates a new dataset with new rows to store data in
 
@@ -360,8 +361,8 @@ class Store(metaclass=ABCMeta):
         hierarchy: ty.Optional[ty.List[str]] = None,
         id_patterns: ty.Optional[ty.Dict[str, str]] = None,
         use_original_paths: bool = False,
-        **kwargs,
-    ):
+        **kwargs: ty.Any,
+    ) -> None:
         """Import a dataset from another store, transferring metadata and columns
         defined on the original dataset
 
@@ -450,7 +451,7 @@ class Store(metaclass=ABCMeta):
             imported.save(name="")
 
     @classmethod
-    def singletons(cls):
+    def singletons(cls) -> "Store":
         """Returns stores in a dictionary indexed by their aliases, for which there
         only needs to be a single instance"""
         try:
@@ -498,7 +499,7 @@ class Store(metaclass=ABCMeta):
     @classmethod
     def save_configs(
         cls, configs: ty.Dict[str, ty.Any], config_path: ty.Optional[Path] = None
-    ):
+    ) -> None:
         """_summary_
 
         Parameters
@@ -519,7 +520,7 @@ class Store(metaclass=ABCMeta):
         ids: ty.Dict[str, str],
         id_patterns: ty.Dict[str, str],
         metadata: ty.Optional[ty.Dict[str, ty.Dict[str, str]]] = None,
-    ):
+    ) -> ty.Dict[str, str]:
         """Infer IDs from those explicitly provided by using the inference patterns
         provided to the dataset definition.
 
@@ -636,7 +637,7 @@ class Store(metaclass=ABCMeta):
                 inferred_ids[freq] = inferred_id
         return inferred_ids
 
-    def get_site_license_file(self, name: str, **kwargs) -> PlainText:
+    def get_site_license_file(self, name: str, **kwargs: ty.Any) -> PlainText:
         """Access the site-wide license file
 
         Parameters
@@ -655,7 +656,7 @@ class Store(metaclass=ABCMeta):
         """
         return self.site_licenses_dataset(**kwargs).get_license_file(name)
 
-    def __bytes_repr__(self, cache):
+    def __bytes_repr__(self, cache: ty.Dict[str, ty.Any]) -> ty.Iterator[bytes]:
         """Bytes representation of store to be used in Pydra input hashing"""
         yield type(self).__module__.encode()
         yield type(self).__name__.encode()
@@ -665,7 +666,7 @@ class Store(metaclass=ABCMeta):
     ####################
 
     @abstractmethod
-    def populate_tree(self, tree: DataTree):
+    def populate_tree(self, tree: DataTree) -> None:
         """
         Populates the nodes of the data tree with those found in the dataset using
         the ``DataTree.add_leaf`` method for every "leaf" node of the dataset tree.
@@ -681,7 +682,7 @@ class Store(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def populate_row(self, row: DataRow):
+    def populate_row(self, row: DataRow) -> None:
         """
         Populate a row with all data entries found in the corresponding node in the data
         store (e.g. files within a directory, scans within an XNAT session) using the
@@ -703,7 +704,7 @@ class Store(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def get(self, entry: DataEntry, datatype: type) -> DataType:
+    def get(self, entry: DataEntry, datatype: ty.Type[DT]) -> DT:
         """
         Gets the data item corresponding to the given entry
 
@@ -721,7 +722,7 @@ class Store(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def put(self, item: DataType, entry: DataEntry) -> DataType:
+    def put(self, item: DT, entry: DataEntry) -> DT:
         """
         Updates the item in the data store corresponding to the given data entry
 
@@ -739,7 +740,9 @@ class Store(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def put_provenance(self, provenance: ty.Dict[str, ty.Any], entry: DataEntry):
+    def put_provenance(
+        self, provenance: ty.Dict[str, ty.Any], entry: DataEntry
+    ) -> None:
         """Stores provenance information for a given data item in the store
 
         Parameters
@@ -769,7 +772,7 @@ class Store(metaclass=ABCMeta):
     @abstractmethod
     def save_frameset_definition(
         self, dataset_id: str, definition: ty.Dict[str, ty.Any], name: str
-    ):
+    ) -> None:
         """Save definition of dataset within the store
 
         Parameters
@@ -818,7 +821,7 @@ class Store(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def disconnect(self, session: ty.Any):
+    def disconnect(self, session: ty.Any) -> None:
         """
         If a connection session is required to the store manage it here
 
@@ -829,7 +832,7 @@ class Store(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def site_licenses_dataset(self):
+    def site_licenses_dataset(self) -> "FrameSet":
         """Can be overridden by subclasses to provide a dataset to hold site-wide licenses"""
 
     @abstractmethod
@@ -838,9 +841,9 @@ class Store(metaclass=ABCMeta):
         id: str,
         leaves: ty.List[ty.Tuple[str, ...]],
         hierarchy: ty.List[str],
-        axes: type,
-        **kwargs,
-    ):
+        axes: ty.Type[Axes],
+        **kwargs: ty.Any,
+    ) -> None:
         """Creates a new empty dataset within in the store. Used in test routines and
         importing/exporting datasets between stores
 
@@ -911,12 +914,13 @@ class Store(metaclass=ABCMeta):
         with self.connection:
             entry = self.create_entry(path, datatype, row)
             self.put(item, entry)
+        return entry
 
     ##################
     # Helper methods #
     ##################
 
-    def check_store_version(self, store_version: str):
+    def check_store_version(self, store_version: str) -> None:
         """Check whether version store used to save the dataset is compatible with the
         current version of the software. Can be overridden by store subclasses where
         appropriate

--- a/frametree/core/tests/test_utils.py
+++ b/frametree/core/tests/test_utils.py
@@ -1,3 +1,5 @@
+import re
+import pytest
 from frametree.core.packaging import package_from_module
 from frametree.core.utils import path2varname, varname2path
 
@@ -7,20 +9,29 @@ def test_package_from_module():
     assert package_from_module("pydra.engine").key == "pydra"
 
 
-def test_path2varname():
-    escape_pairs = [
-        ("dwi/dir-LR_dwi", "dwi__l__dir__H__LR_u_dwi"),
-        ("func/task-rest_bold", "func__l__task__H__rest_u_bold"),
-        (
-            "with spaces and__ underscores",
-            "with__s__spaces__s__and_u__u___s__underscores",
-        ),
-        ("__a.very$illy*ath~", "XXX_u__u_a__o__very__dollar__illy__star__ath__tilde__"),
-        ("anat/T1w", "anat__l__T1w"),
-        ("anat__l__T1w", "anat_u__u_l_u__u_T1w"),
-        ("_u__u_", "XXX_u_u_u__u_u_u_"),
-    ]
-    for path, varname in escape_pairs:
-        assert path2varname(path) == varname
-        assert varname2path(varname) == path
-        assert varname2path(varname2path(path2varname(path2varname(path)))) == path
+PATHS_TO_TEST = [
+    "dwi/dir-LR_dwi",
+    "func/task-rest_bold",
+    "with spaces and___ underscores",
+    "__a.very$illy*ath~",
+    "anat/T1w",
+    "anat___l___T1w",
+    "_u__u_",
+]
+
+
+@pytest.mark.parametrize("path", PATHS_TO_TEST)
+def test_path2varname(path: str):
+    varname = path2varname(path)
+    assert re.match(r"^\w+$", varname)
+    assert varname2path(varname) == path
+
+
+@pytest.mark.parametrize("path", PATHS_TO_TEST)
+def test_triple_path2varname(path: str):
+    assert (
+        varname2path(
+            varname2path(varname2path(path2varname(path2varname(path2varname(path)))))
+        )
+        == path
+    )

--- a/frametree/core/utils.py
+++ b/frametree/core/utils.py
@@ -214,6 +214,17 @@ def varname2path(name: str) -> str:
     return path
 
 
+def path2label(path: str) -> str:
+    return path2varname(path.rstrip("@"))
+
+
+def label2path(label: str) -> str:
+    path = varname2path(label)
+    if "@" not in path:
+        path += "@"
+    return path
+
+
 def func_task(
     func: ty.Callable[..., ty.Any],
     in_fields: ty.List[ty.Tuple[str, ty.Type[ty.Any]]],

--- a/frametree/testing/__init__.py
+++ b/frametree/testing/__init__.py
@@ -1,2 +1,5 @@
 from .axes import TestAxes
 from .store import MockRemote, AlternateMockRemote
+
+
+__all__ = ["TestAxes", "MockRemote", "AlternateMockRemote"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,12 @@ per-file-ignores = ["__init__.py:F401"]
 max-line-length = 88
 select = "C,E,F,W,B,B950"
 extend-ignore = ['E203', 'E501', 'E129', 'W503']
+
+
+[tool.mypy]
+python_version = "3.8"
+ignore_missing_imports = true
+strict = true
+namespace_packages = true
+explicit_package_bases = true
+exclude = ["tests", "scripts", "docs", "build", "dist"]


### PR DESCRIPTION
* `File` items are given stems matching the entry path in `RemoteStore.put_fileset`
* `path2varname` now doesn't mangle underscores and double underscores, using triple underscores as a escape sequence
*  added `FrameSet.address` to replace `locator`
* added type annotations