### PR TITLE
Added bytes_repr overload for DataRow

### DIFF
--- a/frametree/core/row.py
+++ b/frametree/core/row.py
@@ -6,6 +6,11 @@ from frametree.core.exceptions import (
     FrameTreeWrongFrequencyError,
 )
 from fileformats.core import DataType
+from pydra.utils.hash import (
+    register_serializer,
+    Cache,
+    bytes_repr_mapping_contents,
+)
 from .quality import DataQuality
 from .axes import Axes
 from .cell import DataCell
@@ -275,3 +280,13 @@ class DataRow:
             )
         self._entries_dict[path] = entry
         return entry
+
+
+@register_serializer(DataRow)
+def bytes_repr_data_row(row: DataRow, cache: Cache) -> ty.Iterator[bytes]:
+    yield "frametree.core.row.DataRow:(".encode()
+    yield b"frameset.id="
+    yield row.frameset.id.encode()
+    yield b", ids="
+    yield from bytes_repr_mapping_contents(row.ids, cache)
+    yield b")"

--- a/frametree/core/tests/test_row.py
+++ b/frametree/core/tests/test_row.py
@@ -1,0 +1,15 @@
+from pydra.utils.hash import hash_single, Cache
+from fileformats.generic import File
+from frametree.testing import MockRemote
+from frametree.core.frameset import FrameSet
+
+
+def test_row_hash(saved_dataset: FrameSet) -> None:
+    """Test that hashes of rows are consistent across different runs."""
+    row = list(saved_dataset.rows())[0]
+    hsh = hash_single(row, Cache())
+    if isinstance(saved_dataset, MockRemote):
+        assert hsh == b'\xe6"&\xd1D\xb0\xf6\xfc\x8b\xf9\xca\xd4\xda\xa7V\xac'
+    row.create_entry("dummy", File)
+    hsh2 = hash_single(row, Cache())
+    assert hsh2 == hsh, "Hash should not change after adding an entry to the row."


### PR DESCRIPTION
Added `bytes_repr` overload for DataRow so it can be passed as an input to Pydra tasks